### PR TITLE
docs: update helmchart repository url

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -41,7 +41,7 @@
 | Type | Highlight |
 |------|-----------|
 | **Terraform Modules** | [AWS](https://github.com/clouddrove?q=terraform-aws&type=all&language=&sort=), [GCP](https://github.com/clouddrove?q=terraform-gcp&type=all&language=&sort=), [DO](https://github.com/terraform-do-modules?q=terraform-digitalocean&type=all&language=&sort=)|
-| **Helm Charts** | [helm-charts](https://github.com/clouddrove/helm-charts) |
+| **Helm Charts** | [helm-charts](https://github.com/clouddrove/helmchart) |
 | **GitHub Actions** | Shared workflows to standardise CI/CD |
 | **Security Baselines** | Standard infra guardrails (e.g., secure baseline module) |
 


### PR DESCRIPTION
## What

- Update correct URL for clouddrove's helmchart github repository.

## Why

- The URL mentioned under `profile/README.md` is incorrect (i.e. `https://github.com/clouddrove/helm-charts`)

## How

N/A

## Checklist

- [x] Code follows existing conventions
- [ ] Updated or added examples in `examples/`
- [ ] Ran `pre-commit run -a` locally
- [x] Updated documentation if needed
- [ ] All CI checks pass

## References

- `clouddrove/helmchart` github repo url - https://github.com/clouddrove/helmchart
